### PR TITLE
accept zero (0) as a bus ID

### DIFF
--- a/smbus2/smbus2.py
+++ b/smbus2/smbus2.py
@@ -125,7 +125,7 @@ class SMBus(object):
         """
         self.fd = None
         self.funcs = 0
-        if bus:
+        if bus is not None:
             self.open(bus)
         self.address = None
 


### PR DESCRIPTION
previously a bus ID of zero did not trigger the implicite "open" call
during the object initialization