### PR TITLE
Add a force flag that adds similar functionality to i2cget -f flag

### DIFF
--- a/smbus2/smbus2.py
+++ b/smbus2/smbus2.py
@@ -153,6 +153,7 @@ class SMBus(object):
         :param address:
         """
         if self.address != address:
+            self.address = address
             ioctl(self.fd, I2C_SLAVE, address)
 
     def _get_funcs(self):


### PR DESCRIPTION
Force flag is useful when a kernel driver is already loaded and using that I2C address but you still want to access the device using raw I2C commands.

Also no other python I2C library implements this.