### PR TITLE
Add read()/write() to the SMBus class

### DIFF
--- a/smbus2/smbus2.py
+++ b/smbus2/smbus2.py
@@ -482,6 +482,15 @@ class SMBus(object):
         ioctl_data = i2c_rdwr_ioctl_data.create(*i2c_msgs)
         ioctl(self.fd, I2C_RDWR, ioctl_data)
 
+    def read(self, address, length):
+        msg = i2c_msg.read(address, length)
+        self.i2c_rdwr(msg)
+        return list(msg)
+
+    def write(self, address, buf):
+        msg = i2c_msg.write(address, buf)
+        self.i2c_rdwr(msg)
+
 
 class SMBusWrapper:
     """


### PR DESCRIPTION
The i2c_rdwr() function is really nice as some kind of i2c transfers can only be achieved with it and not with other smbus available commands.

However, to use this function, one need knowledge of the i2c_msg class so it cannot decouple as much from the bus type as for the other smbus functions.

With these two new functions, a device class can receive a bus object and do simple reads and writes without having a hard coupling to this library by having to import i2c_msg.

See this example:
https://github.com/fgervais/Si7021/commit/e0f407ca0c6f97c866ddfc2932c57796610917ee

In that case, the device class receives a bus instance and need no knowledge of the implementation other than the functions it needs to use on it.

I also think these functions can be a nice add-on in any case.

I hope this makes sense.