### PR TITLE
SMBus Quick command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
           env: TOXENV=py35
         - python: 3.6
           env: TOXENV=py36
-        - python: 3.7
+        - python: 3.7-dev
           env: TOXENV=py37
         - python: 3.5
           env: TOXENV=qa,doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
           env: TOXENV=py35
         - python: 3.6
           env: TOXENV=py36
+        - python: 3.7
+          env: TOXENV=py37
         - python: 3.5
           env: TOXENV=qa,doc
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Currently supported features are:
 * write_word_data
 * read_i2c_block_data
 * write_i2c_block_data
+* write_quick
 * i2c_rdwr - *combined write/read transactions with repeated start*
 
 It is developed on Python 2.7 but works without any modifications in Python 3.X too.

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ Currently supported features are:
 * write_word_data
 * read_i2c_block_data
 * write_i2c_block_data
+* write_quick
 * i2c_rdwr - *combined write/read transactions with repeated start*
 
 It is developed on Python 2.7 but works without any modifications in Python 3.X too.
@@ -115,7 +116,8 @@ I2C
 Starting with v0.2, the smbus2 library also has support for combined read and write transactions. *i2c_rdwr* is not really a SMBus feature but comes in handy when the master needs to:
 
 1. read or write bulks of data larger than SMBus' 32 bytes limit.
-1. write some data and then read from the slave with a repeated start and no stop bit between.
+
+2. write some data and then read from the slave with a repeated start and no stop bit between.
 
 Each operation is represented by a *i2c_msg* message object.
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6"
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7"
     ],
 )

--- a/smbus2/__init__.py
+++ b/smbus2/__init__.py
@@ -22,4 +22,4 @@
 
 from .smbus2 import SMBus, SMBusWrapper, i2c_msg  # noqa: F401
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/smbus2/smbus2.py
+++ b/smbus2/smbus2.py
@@ -38,6 +38,7 @@ I2C_SMBUS_WRITE = 0
 I2C_SMBUS_READ = 1
 
 # Size identifiers uapi/linux/i2c.h
+I2C_SMBUS_QUICK = 0
 I2C_SMBUS_BYTE = 1
 I2C_SMBUS_BYTE_DATA = 2
 I2C_SMBUS_WORD_DATA = 3
@@ -299,6 +300,19 @@ class SMBus(object):
         f = c_uint32()
         ioctl(self.fd, I2C_FUNCS, f)
         return f.value
+
+    def write_quick(self, i2c_addr, force=None):
+        """
+        Perform quick transaction. Throws IOError if unsuccessful.
+        :param i2c_addr: i2c address
+        :type i2c_addr: int
+        :param force:
+        :type force: Boolean
+        """
+        self._set_address(i2c_addr, force=force)
+        msg = i2c_smbus_ioctl_data.create(
+            read_write=I2C_SMBUS_WRITE, command=0, size=I2C_SMBUS_QUICK)
+        ioctl(self.fd, I2C_SMBUS, msg)
 
     def read_byte(self, i2c_addr, force=None):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36},qa,doc
+envlist = py{27,34,35,36,37},qa,doc
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Finally, issue #7 implemented. 

New function in the SMBus class:
`write_quick(address)` raises an `IOError` exception if there is no slave device responding on the given address. If all goes well and the device is there, no exception will be raised.
