### PR TITLE
Add missing SMBus operations: block_read, block_write, proc_call, block_proc_call

### DIFF
--- a/smbus2/smbus2.py
+++ b/smbus2/smbus2.py
@@ -42,6 +42,7 @@ I2C_SMBUS_QUICK = 0
 I2C_SMBUS_BYTE = 1
 I2C_SMBUS_BYTE_DATA = 2
 I2C_SMBUS_WORD_DATA = 3
+I2C_SMBUS_PROC_CALL = 4
 I2C_SMBUS_BLOCK_DATA = 5  # Can't get this one to work on my Raspberry Pi
 I2C_SMBUS_I2C_BLOCK_DATA = 8
 I2C_SMBUS_BLOCK_MAX = 32
@@ -430,6 +431,28 @@ class SMBus(object):
         )
         msg.data.contents.word = value
         ioctl(self.fd, I2C_SMBUS, msg)
+
+    def process_call(self, i2c_addr, register, value, force=None):
+        """
+        Executes a SMBus Process Call, sending a 16-bit value and receiving a 16-bit response
+
+        :param i2c_addr: i2c address
+        :type i2c_addr: int
+        :param register: Register to read/write to
+        :type register: int
+        :param value: Word value to transmit
+        :type value: int
+        :param force:
+        :type force: Boolean
+        :rtype: int
+        """
+        self._set_address(i2c_addr, force=force)
+        msg = i2c_smbus_ioctl_data.create(
+            read_write=I2C_SMBUS_WRITE, command=register, size=I2C_SMBUS_PROC_CALL
+        )
+        msg.data.contents.word = value
+        ioctl(self.fd, I2C_SMBUS, msg)
+        return msg.data.contents.word
 
     def read_i2c_block_data(self, i2c_addr, register, length, force=None):
         """


### PR DESCRIPTION
The patch is quite straightforward, just adds the missing methods.

Interesting bits are:
- On `process_call`, I use `read_write=I2C_SMBUS_WRITE`, just because I saw it  being used like this on an old [kernel source](https://elixir.bootlin.com/linux/v3.1/source/drivers/i2c/i2c-core.c#L1807), but the correct value doesn't seem to be documented anywhere -- Indeed, it doesn't seem to be used. Anyway, this works.
- Both `read_block_data` and `block_process_call` are _not_ supported by vanilla I2C drivers with SMBus emulation -- Like those in our favorite Fruit-Pi devices --, and results in only 1 byte being transferred (the block size)