### PR TITLE
Use decode to convert __bytes__ to __str__

### DIFF
--- a/smbus2/smbus2.py
+++ b/smbus2/smbus2.py
@@ -182,8 +182,8 @@ class i2c_msg(Structure):
 
     def __str__(self):
         s = self.__bytes__()
-        if sys.version_info.major >= 3:
-            s = ''.join(map(chr, s))
+        # Throw away non-decodable bytes
+        s = s.decode(errors="ignore")
         return s
 
     @staticmethod

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -81,7 +81,7 @@ class TestDataTypes(unittest.TestCase):
         self.assertEqual(msg2.len, msg.len)
         self.assertEqual(msg2.flags, msg.flags)
         self.assertListEqual(list(msg), list(msg2))
-        self.assertEqual(str(msg2)[0:4], "ABCD")
+        self.assertEqual(str(msg2), "ABCD\x01\n")
         self.assertGreaterEqual(('%r' % msg2).find(r"ABCD\x01\n\xff"), 0)
 
     def test_i2c_msg_iter(self):


### PR DESCRIPTION
The test did not cover the case, when the byte can not be decoded via 'chr'.
For the sake of simplicity, just use the 'decode' bytes method and ignore non-utf-8 characters, so no error will be thrown.

Arguably, these could also replaced with ''''.