### PR TITLE
Exemple i2c_msg.write() for a single byte (list required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Each operation is represented by a *i2c_msg* message object.
         msg = i2c_msg.read(80, 64)
         bus.i2c_rdwr(msg)
         
+        # Write a single byte to address 80
+        msg = i2c_msg.write(80, [65])
+        bus.i2c_rdwr(msg)
+        
         # Write some bytes to address 80
         msg = i2c_msg.write(80, [65, 66, 67, 68])
         bus.i2c_rdwr(msg)

--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ Starting with v0.2, the smbus2 library also has support for combined read and wr
 
 2. write some data and then read from the slave with a repeated start and no stop bit between.
 
-Each operation is represented by a *i2c_msg* message object.
+Each operation is represented by a *i2c_msg* message object. For i2c_msg.write(), 
 
 
 Example 5: Single i2c_rdwr
@@ -138,6 +138,10 @@ Example 5: Single i2c_rdwr
     with SMBus(1) as bus:
         # Read 64 bytes from address 80
         msg = i2c_msg.read(80, 64)
+        bus.i2c_rdwr(msg)
+        
+        # Write a single byte to address 80
+        msg = i2c_msg.write(80, [65])
         bus.i2c_rdwr(msg)
 
         # Write some bytes to address 80

--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ Starting with v0.2, the smbus2 library also has support for combined read and wr
 
 2. write some data and then read from the slave with a repeated start and no stop bit between.
 
-Each operation is represented by a *i2c_msg* message object. For i2c_msg.write(), 
+Each operation is represented by a *i2c_msg* message object.
 
 
 Example 5: Single i2c_rdwr


### PR DESCRIPTION
Exemplified that even a single byte has to be given as a list for i2c_msg.write(). Might be obvious for most, but given that i2c_msg.read() takes a plain value, it's easy to get misled.