### PR TITLE
distribute license file, changelog, and readme

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include CHANGELOG.md
+include LICENSE
+include README.md
+include README.rst
+


### PR DESCRIPTION
Currently you do not distribute your own LICENSE on PyPI. This makes redistribution of smbus2 awkward. By adding a MANIFEST you can tell setuptools to package these extra files.