### PR TITLE
Added enable_pec to Enable/Disable PEC

### DIFF
--- a/smbus2/smbus2.py
+++ b/smbus2/smbus2.py
@@ -32,6 +32,7 @@ I2C_SLAVE_FORCE = 0x0706  # Use this slave address, even if it is already in use
 I2C_FUNCS = 0x0705  # Get the adapter functionality mask
 I2C_RDWR = 0x0707  # Combined R/W transfer (one STOP only)
 I2C_SMBUS = 0x0720  # SMBus transfer. Takes pointer to i2c_smbus_ioctl_data
+I2C_PEC = 0x0708 # != 0 to use PEC with SMBus 
 
 # SMBus transfer read or write markers from uapi/linux/i2c.h
 I2C_SMBUS_WRITE = 0
@@ -316,6 +317,18 @@ class SMBus(object):
             os.close(self.fd)
             self.fd = None
 
+    def enable_pec(self, enable=True):
+        """
+        Enable/Disable PEC (Packet Error Checking) - SMBus 1.1 and later
+        
+        Contributed by Riccardo Gusmeroli 2020
+        """
+
+        if not (self.funcs & I2cFunc.SMBUS_PEC):
+            raise ValueError('SMBUS_PEC is not a feature')
+
+        ioctl(self.fd,I2C_PEC,int(enable))          
+            
     def _set_address(self, address, force=None):
         """
         Set i2c slave address to use for subsequent calls.

--- a/smbus2/smbus2.py
+++ b/smbus2/smbus2.py
@@ -321,14 +321,19 @@ class SMBus(object):
         """
         Enable/Disable PEC (Packet Error Checking) - SMBus 1.1 and later
         
-        Contributed by Riccardo Gusmeroli 2020
+        Contributed by Riccardo Gusmeroli (2020)
+        
+        :param enable:
+        :type enable: Boolean
         """
 
         if not (self.funcs & I2cFunc.SMBUS_PEC):
-            raise ValueError('SMBUS_PEC is not a feature')
+            raise IOError('SMBUS_PEC is not a feature')
 
         ioctl(self.fd,I2C_PEC,int(enable))          
-            
+
+    pec=property(None, enable_pec) # Drop-in replacement for smbus member "pec"
+        
     def _set_address(self, address, force=None):
         """
         Set i2c slave address to use for subsequent calls.

--- a/smbus2/smbus2.py
+++ b/smbus2/smbus2.py
@@ -330,7 +330,7 @@ class SMBus(object):
         if not (self.funcs & I2cFunc.SMBUS_PEC):
             raise IOError('SMBUS_PEC is not a feature')
 
-        ioctl(self.fd,I2C_PEC,int(enable))          
+        ioctl(self.fd, I2C_PEC, int(enable))          
 
     pec=property(None, enable_pec) # Drop-in replacement for smbus member "pec"
         


### PR DESCRIPTION
Added member function enable_pec to SMBus to Enable/Disable PEC (Packet Error Checking, see SMBus 1.1 and later).

Some devices require it (e.g. MLX90614), in particular when writing data (because they expect - and check - 1 more byte, i.e. the PEC crc, in the data string).

Example:
    bus=smbus2.SMBus(1)
    bus.enable_pec()