### PR TITLE
Include the tests folder in the distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Notable changes to the smbus2 project are recorded here.
 ## [Unreleased]
 ###
 - SonarCloud quality checks
+- Tests added to the dist package.
 
 ## [0.4.0] - 2020-12-05
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include CHANGELOG.md
 include LICENSE
 include README.md
-
+graft tests


### PR DESCRIPTION
This will allow downstream package managers (such as [`nix`](https://github.com/NixOS/nixpkgs)) to run tests straight from the package in PyPI.

To give more context, I am trying to add this package to NixOS which uses the `nix` package manager. This package manager runs tests on its own, that's why it needs tests in the PyPI package (otherwise no tests are executed which makes release automation less trustworthy).