### PR TITLE
Explicitly export from top level of package

### DIFF
--- a/smbus2/__init__.py
+++ b/smbus2/__init__.py
@@ -23,3 +23,4 @@
 from .smbus2 import SMBus, i2c_msg, I2cFunc  # noqa: F401
 
 __version__ = "0.4.1"
+__all__ = ["SMBus", "i2c_msg", "I2cFunc"]


### PR DESCRIPTION
This stops mypy from complaining when you use:

```python
from smbus2 import SMBus  # Module 'smbus2' does not explicitly export attribute 'SMBus'; implicit reexport disabled
```