### PR TITLE
Housekeeping

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -8,10 +8,10 @@ on:
     
 jobs:
   build-py3:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -31,11 +31,11 @@ jobs:
         run: |
           pytest --capture=no
 
-  build-py2:
-    runs-on: ubuntu-18.04
+  build-py_legacy:
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["2.7"]
+        python-version: ["2.7", "3.6"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -56,7 +56,7 @@ jobs:
           pytest --capture=no
 
   build-docs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .tox/
 doc/_build
+doc/doctrees
+doc/html
 build/
 dist/
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 Notable changes to the smbus2 project are recorded here.
 
 ## [Unreleased]
-No unreleased updates.
+- Build pipeline and test updates only:
+  - Upgrade build pipelines
+    - Added Python 3.11
+    - Python 3.4 and 3.5 no longer tested. 
+- Update deprecated Sphinx config format.
+- Corrected deprecated `assertEquals` in the unit tests.
 
 ## [0.4.2] - 2022-06-05
 ### General

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,7 +22,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 
-from smbus2 import __version__
+from smbus2 import __version__  # noqa: E402
 
 
 # -- General configuration ------------------------------------------------
@@ -34,8 +34,10 @@ from smbus2 import __version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -171,4 +173,4 @@ texinfo_documents = [
 
 
 # Configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/2/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3/', None)}

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,6 @@ exclude =
     doc,
     build,
     dist
+
+[pycodestyle]
+max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10"
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11"
     ],
 )

--- a/tests/test_smbus2.py
+++ b/tests/test_smbus2.py
@@ -66,7 +66,7 @@ def mock_open(*args):
 
 
 def mock_close(*args):
-    True
+    return
 
 
 def mock_read(fd, length):


### PR DESCRIPTION
- Bumped build image versions.
- Run tests for Python 3.11
- Drop testing for Python 3.4 and 3.5. Images no longer availble to do this.
- Sphinx config updates to stay up to date