### PR TITLE
Don't attempt to run Python 2.7 GitHub workflow

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["2.7", "3.6"]
+        python-version: ["3.6"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Notable changes to the smbus2 project are recorded here.
 - Build pipeline and test updates only:
   - Upgrade build pipelines
     - Added Python 3.11
-    - Python 3.4 and 3.5 no longer tested. 
+    - Python 2.7, 3.4, and 3.5 no longer tested.
 - Update deprecated Sphinx config format.
 - Corrected deprecated `assertEquals` in the unit tests.
 


### PR DESCRIPTION
Effective 2023-06-19, GitHub Actions has removed support for Python 2.7. See https://github.com/actions/setup-python/issues/672 and https://github.com/actions/python-versions/commit/87d20c715fb88616b9231bdb676ef2b2825c47f8. Since then, the smbus2 build-py_legacy (2.7) job has failed, for example,
https://github.com/kplindegaard/smbus2/actions/runs/5895472485/job/15991316082.

This does not change the status of Python 2.7 support by smbus2 code. It only disables the unsupported configuration in the GitHub workflow.