### PR TITLE
Python 3.12 build and test

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -22,6 +22,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest
+      - name: Additional install for Python 3.12 or higher
+        if: ${{ matrix.python-version >= '3.12' }}
+        run: |
+          pip install setuptools
+      - name: Install smbus2
+        run: |
           python setup.py install
       - name: Lint with flake8
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Notable changes to the smbus2 project are recorded here.
 
 ## [Unreleased]
-No changes since last release.
+- Python 3.12 added.
 
 ## [0.4.3] - 2023-08-25
 - Build pipeline and test updates only:

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11"
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,6 @@ def find_version(*file_paths):
 
 README = read_file('README.md')
 version = find_version('smbus2', '__init__.py')
-test_deps = [
-    'mock;python_version<"3.3"',
-    'nose'
-]
 
 setup(
     name="smbus2",
@@ -50,8 +46,7 @@ setup(
         ],
         'qa': [
             'flake8'
-        ],
-        'test': test_deps
+        ]
     },
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -60,8 +55,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Formalizing Python 3.12 support: Updated actions and metainfo.