### PR TITLE
fix: just support tested python versions >=3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Currently supported features are:
 * block_process_call
 * i2c_rdwr - *combined write/read transactions with repeated start*
 
-It is developed on Python 2.7 but works without any modifications in Python 3.X too.
+It is developed for Python 3.
 
 More information about updates and general changes are recorded in the [change log](https://github.com/kplindegaard/smbus2/blob/master/CHANGELOG.md).
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     package_data={'smbus2': ['py.typed', 'smbus2.pyi']},
     long_description=README,
     long_description_content_type="text/markdown",
+    requires_python=">=3.7",
     extras_require={
         'docs': [
             'sphinx >= 7',
@@ -53,10 +54,7 @@ setup(
         "Development Status :: 4 - Beta",
         "Topic :: Utilities",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
### Reference

fixes #128
