### PR TITLE
Fixup docs build action and non-functioning readme badges

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r doc/requirements.txt
+          python -m pip install --only-binary=:all: -r doc/requirements.txt
       - name: Build docs with Sphinx
         run: |
           cd doc

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A drop-in replacement for smbus-cffi/smbus-python in pure Python
 
 ![Python Versions](https://img.shields.io/pypi/pyversions/smbus2.svg)
 [![PyPi Version](https://img.shields.io/pypi/v/smbus2.svg)](https://pypi.org/project/smbus2/)
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/smbus2)](https://pypi.org/project/smbus2/)
+[![PyPI - Downloads](https://api.pepy.tech/badge/smbus2/month)](https://pypi.org/project/smbus2/)
 
 # Introduction
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -6,6 +6,7 @@
 [![](https://readthedocs.org/projects/smbus2/badge/?version=latest)](http://smbus2.readthedocs.io/en/latest/?badge=latest)
 [![](https://img.shields.io/pypi/pyversions/smbus2.svg)](https://pypi.python.org/pypi/smbus2)
 [![](https://img.shields.io/pypi/v/smbus2.svg)](https://pypi.python.org/pypi/smbus2)
+[![](https://api.pepy.tech/badge/smbus2/month)](https://pypi.org/project/smbus2/)
 
 **smbus2** is a pure-Python, drop-in replacement for the `python-smbus` /
 `python3-smbus` Linux SMBus bindings. It wraps the Linux kernel's I2C/SMBus `ioctl`

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
-sphinx>=7
-sphinx-rtd-theme
-myst-parser
+sphinx==9.1.0
+sphinx-rtd-theme==3.1.0
+myst-parser==5.1.0


### PR DESCRIPTION
Maintenance:
- Silencing a trival sonar warnings registered for the docs build.
- Vanity fix (!) replacing the non-functioning download counter badge